### PR TITLE
upgrade to junit5 and mockito4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ public void someMethod(..) {
    @Mock
    GlobalConfig globalConfig;
    
-   @Before
+   @BeforeEach
    public void setUp() {
      ...
      GlobalConfig.setInstance(globalConfig);
@@ -73,7 +73,7 @@ public void someMethod(..) {
    
    ```java
    
-   @After
+   @AfterEach
    public void tearDown() {
      GlobalConfig.setInstance(null);
    }
@@ -140,14 +140,12 @@ staticメソッドを多用している場合、そのクラスのWrapperクラ�
 4. テスト時にMockインスタンスに差し替える。
 
    ```java
+   @InjectMocks
    SomeClass it;
   
    @Mock
    DictWrapper dict;
   
   
-   public void setUp() {
-     it = new SomeClass(it);
-   }
    ```
    

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ targetCompatibility = 1.8
 dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
-
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.h2database:h2:1.4.200'
@@ -36,10 +35,13 @@ dependencies {
 
 
     // Use JUnit test framework
-    testImplementation 'junit:junit:4.13'
+    testImplementation (platform 'org.junit:junit-bom:5.8.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.hamcrest:hamcrest-core:2.2'
-    testImplementation 'org.mockito:mockito-core:3.5.13'
+    testImplementation 'org.mockito:mockito-core:4.0.0'
+    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
 
     providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/legacy/example/StaticAPIUserRefactoredTest.java
+++ b/src/test/java/com/legacy/example/StaticAPIUserRefactoredTest.java
@@ -2,22 +2,24 @@ package com.legacy.example;
 
 import static org.mockito.Mockito.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoSettings;
 
-@RunWith(MockitoJUnitRunner.class)
+
+@MockitoSettings
 public class StaticAPIUserRefactoredTest {
 	@Mock
 	StaticAPIWrapper staticAPI;
 
+	@InjectMocks
 	StaticAPIUserRefactored it;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		it = new StaticAPIUserRefactored(staticAPI);
+	//	it = new StaticAPIUserRefactored(staticAPI);
 	}
 
 	@Test

--- a/src/test/java/com/legacy/example/StaticAPIUserTest.java
+++ b/src/test/java/com/legacy/example/StaticAPIUserTest.java
@@ -1,0 +1,50 @@
+package com.legacy.example;
+
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+@MockitoSettings
+class StaticAPIUserTest {
+
+	MockedStatic<StaticAPI> staticAPI;
+
+	@InjectMocks
+	StaticAPIUser it;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		staticAPI = Mockito.mockStatic(StaticAPI.class, Answers.RETURNS_DEFAULTS);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		staticAPI.close();
+	}
+
+	@Test
+	void doit_call_google_java() {
+		it.doit();
+		staticAPI.verify(() -> StaticAPI.google("java"), times(1));
+	}
+
+	@Test
+	void doit_call_launchICBM() {
+		it.doit();
+		staticAPI.verify(StaticAPI::launchICBM, times(1));
+	}
+
+	@Test
+	void doit_call_eject() {
+		it.doit();
+		staticAPI.verify(StaticAPI::eject, times(1));
+	}
+
+}


### PR DESCRIPTION
closes #2 

# Description
テストフレームワークをバージョンアップします。

- JUnit4 -> JUni5
- Mockito3 -> Mockito4
- Mockito-inline 追加

# そのほかの変更点
- mockStaticを用いたテストの例を追加
- gradle7.2にアップグレード（Eclipse 21.09対応のため）